### PR TITLE
Safety and other improvements to update.sh

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -23,7 +23,7 @@ readonly libs="${sdk}/usr/lib"
 # Cosmetic. Debug using https://bashdb.sourceforge.net/ if there's issues.
 set -x
 
-# Remove prior output of "update.sh".
+# Remove prior output of the script you are currently inside.
 rm -rf "Frameworks/"
 
 mkdir -p "{./Frameworks, ./include, ./lib}"
@@ -102,7 +102,7 @@ find . | grep "\.modulemap" | xargs rm -rf
 # 668K
 rm "./Frameworks/OpenGL.framework/Versions/A/Libraries/libLLVMContainer.tbd"
 
-# 6"72K"
+# 672K
 rm "./Frameworks/OpenGL.framework/Versions/A/Libraries/3425AMD/libLLVMContainer.tbd"
 
 # 444K

--- a/update.sh
+++ b/update.sh
@@ -1,95 +1,109 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eu
+
+if [[ $(id -u) -ne 0 ]]; then
+    clear
+    echo -e "Superuser is required for \"${BASH_SOURCE[*]}\", please run it with either sudo or doas.\n" >&2
+    exit 1
+fi
+
+readonly sdk="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk"
+if [[ ! -d "${sdk}" ]]; then
+    clear
+    echo -e "\nERROR: Directory \"${sdk}\" does not exist. \
+    \nPlease install Command Line Tools for Xcode! \
+    \nIf this is a bug, make a pull request updating the macOS SDK version.\n"
+    exit 1
+fi
+
+readonly frameworks="${sdk}/System/Library/Frameworks"
+readonly includes="${sdk}/usr/include"
+readonly libs="${sdk}/usr/lib"
+
+# Cosmetic. Debug using https://bashdb.sourceforge.net/ if there's issues.
 set -x
 
-sdk='/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk'
-frameworks="$sdk/System/Library/Frameworks"
-includes="$sdk/usr/include"
-libs="$sdk/usr/lib"
+# Remove prior output of "update.sh".
+rm -rf "Frameworks/"
 
-rm -rf Frameworks/
-
-mkdir -p ./Frameworks
-mkdir -p ./include
-mkdir -p ./lib
+mkdir -p "{./Frameworks, ./include, ./lib}"
 
 # General includes
-mkdir -p include/libDER/
-cp $includes/libDER/DERItem.h ./include/libDER/
-cp $includes/libDER/libDER_config.h ./include/libDER/
+mkdir -p "include/libDER/"
+cp "${includes}/libDER/DERItem.h" ./include/libDER/
+cp "${includes}/libDER/libDER_config.h" ./include/libDER/
 mkdir -p include/cups
-cp -R $includes/cups ./include/
+cp -R "${includes}"/cups ./include/
 
 # General libraries
 mkdir -p lib/
-cp $libs/libobjc.tbd ./lib/
-cp $libs/libobjc.A.tbd ./lib/
+cp "${libs}"/libobjc.tbd ./lib/
+cp "${libs}"/libobjc.A.tbd ./lib/
 
 # General frameworks
-cp -R $frameworks/CoreFoundation.framework ./Frameworks/CoreFoundation.framework
-cp -R $frameworks/Foundation.framework ./Frameworks/Foundation.framework
-cp -R $frameworks/IOKit.framework ./Frameworks/IOKit.framework
-cp -R $frameworks/Security.framework ./Frameworks/Security.framework
-cp -R $frameworks/CoreServices.framework ./Frameworks/CoreServices.framework
-cp -R $frameworks/DiskArbitration.framework ./Frameworks/DiskArbitration.framework
-cp -R $frameworks/CFNetwork.framework ./Frameworks/CFNetwork.framework
-cp -R $frameworks/ApplicationServices.framework ./Frameworks/ApplicationServices.framework
-cp -R $frameworks/ImageIO.framework ./Frameworks/ImageIO.framework
+cp -R "${frameworks}/CoreFoundation.framework"       "./Frameworks/CoreFoundation.framework"
+cp -R "${frameworks}/Foundation.framework"           "./Frameworks/Foundation.framework"
+cp -R "${frameworks}/IOKit.framework"                "./Frameworks/IOKit.framework"
+cp -R "${frameworks}/Security.framework"             "./Frameworks/Security.framework"
+cp -R "${frameworks}/CoreServices.framework"         "./Frameworks/CoreServices.framework"
+cp -R "${frameworks}/DiskArbitration.framework"      "./Frameworks/DiskArbitration.framework"
+cp -R "${frameworks}/CFNetwork.framework"            "./Frameworks/CFNetwork.framework"
+cp -R "${frameworks}/ApplicationServices.framework"  "./Frameworks/ApplicationServices.framework"
+cp -R "${frameworks}/ImageIO.framework"              "./Frameworks/ImageIO.framework"
 
 # Audio frameworks
-cp -R $frameworks/AudioToolbox.framework ./Frameworks/AudioToolbox.framework
-cp -R $frameworks/CoreAudio.framework ./Frameworks/CoreAudio.framework
-cp -R $frameworks/CoreAudioTypes.framework ./Frameworks/CoreAudioTypes.framework
-cp -R $frameworks/AudioUnit.framework ./Frameworks/AudioUnit.framework
+cp -R "${frameworks}/AudioToolbox.framework"    "./Frameworks/AudioToolbox.framework"
+cp -R "${frameworks}/CoreAudio.framework"       "./Frameworks/CoreAudio.framework"
+cp -R "${frameworks}/CoreAudioTypes.framework"  "./Frameworks/CoreAudioTypes.framework"
+cp -R "${frameworks}/AudioUnit.framework"       "./Frameworks/AudioUnit.framework"
 
 # Graphics frameworks
-cp -R $frameworks/Metal.framework ./Frameworks/Metal.framework
-cp -R $frameworks/OpenGL.framework ./Frameworks/OpenGL.framework
-cp -R $frameworks/CoreGraphics.framework ./Frameworks/CoreGraphics.framework
-cp -R $frameworks/IOSurface.framework ./Frameworks/IOSurface.framework
-cp -R $frameworks/QuartzCore.framework ./Frameworks/QuartzCore.framework
-cp -R $frameworks/CoreImage.framework ./Frameworks/CoreImage.framework
-cp -R $frameworks/CoreVideo.framework ./Frameworks/CoreVideo.framework
-cp -R $frameworks/CoreText.framework ./Frameworks/CoreText.framework
-cp -R $frameworks/ColorSync.framework ./Frameworks/ColorSync.framework
+cp -R "${frameworks}/Metal.framework"         "./Frameworks/Metal.framework"
+cp -R "${frameworks}/OpenGL.framework"        "./Frameworks/OpenGL.framework"
+cp -R "${frameworks}/CoreGraphics.framework"  "./Frameworks/CoreGraphics.framework"
+cp -R "${frameworks}/IOSurface.framework"     "./Frameworks/IOSurface.framework"
+cp -R "${frameworks}/QuartzCore.framework"    "./Frameworks/QuartzCore.framework"
+cp -R "${frameworks}/CoreImage.framework"     "./Frameworks/CoreImage.framework"
+cp -R "${frameworks}/CoreVideo.framework"     "./Frameworks/CoreVideo.framework"
+cp -R "${frameworks}/CoreText.framework"      "./Frameworks/CoreText.framework"
+cp -R "${frameworks}/ColorSync.framework"     "./Frameworks/ColorSync.framework"
 
 # GLFW dependencies
-cp -R $frameworks/Carbon.framework ./Frameworks/Carbon.framework
-cp -R $frameworks/Cocoa.framework ./Frameworks/Cocoa.framework
-cp -R $frameworks/AppKit.framework ./Frameworks/AppKit.framework
-cp -R $frameworks/CoreData.framework ./Frameworks/CoreData.framework
-cp -R $frameworks/CloudKit.framework ./Frameworks/CloudKit.framework
-cp -R $frameworks/CoreLocation.framework ./Frameworks/CoreLocation.framework
-cp -R $frameworks/Kernel.framework ./Frameworks/Kernel.framework
+cp -R "${frameworks}/Carbon.framework"        "./Frameworks/Carbon.framework"
+cp -R "${frameworks}/Cocoa.framework"         "./Frameworks/Cocoa.framework"
+cp -R "${frameworks}/AppKit.framework"        "./Frameworks/AppKit.framework"
+cp -R "${frameworks}/CoreData.framework"      "./Frameworks/CoreData.framework"
+cp -R "${frameworks}/CloudKit.framework"      "./Frameworks/CloudKit.framework"
+cp -R "${frameworks}/CoreLocation.framework"  "./Frameworks/CoreLocation.framework"
+cp -R "${frameworks}/Kernel.framework"        "./Frameworks/Kernel.framework"
 
 # Remove unnecessary files
-find . | grep '\.swiftmodule' | xargs rm -rf
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/ndrvsupport
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/pwr_mgt
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/scsi
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/firewire
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/storage
-rm -rf Frameworks/IOKit.framework/Versions/A/Headers/usb
+find . | grep "\.swiftmodule" | xargs rm -rf
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/ndrvsupport"
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/pwr_mgt"
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/scsi"
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/firewire"
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/storage"
+rm -rf "Frameworks/IOKit.framework/Versions/A/Headers/usb"
 
-# Trim large frameworks
-
+# == Trim large frameworks ==
 # 4.9M -> 1M
-cat ./Frameworks/Foundation.framework/Versions/C/Foundation.tbd | grep -v 'libswiftFoundation' > tmp
-mv tmp ./Frameworks/Foundation.framework/Versions/C/Foundation.tbd
+< "./Frameworks/Foundation.framework/Versions/C/Foundation.tbd" grep -v "libswiftFoundation" | tmp
+mv tmp "./Frameworks/Foundation.framework/Versions/C/Foundation.tbd"
 
 # 13M -> 368K
-find ./Frameworks/Kernel.framework -type f | grep -v IOKit/hidsystem | xargs rm -rf
+find "./Frameworks/Kernel.framework" -type f | grep -v "IOKit/hidsystem" | xargs rm -rf
 
 # 29M -> 28M
-find . | grep '\.apinotes' | xargs rm -rf
-find . | grep '\.r' | xargs rm -rf
-find . | grep '\.modulemap' | xargs rm -rf
+find . | grep "\.apinotes" | xargs rm -rf
+find . | grep "\.r" | xargs rm -rf
+find . | grep "\.modulemap" | xargs rm -rf
 
 # 668K
-rm ./Frameworks/OpenGL.framework/Versions/A/Libraries/libLLVMContainer.tbd
+rm "./Frameworks/OpenGL.framework/Versions/A/Libraries/libLLVMContainer.tbd"
 
-# 672K
-rm ./Frameworks/OpenGL.framework/Versions/A/Libraries/3425AMD/libLLVMContainer.tbd
+# 6"72K"
+rm "./Frameworks/OpenGL.framework/Versions/A/Libraries/3425AMD/libLLVMContainer.tbd"
 
 # 444K
-rm ./Frameworks/CloudKit.framework/Versions/A/CloudKit.tbd
+rm "./Frameworks/CloudKit.framework/Versions/A/CloudKit.tbd"


### PR DESCRIPTION
`- [✅] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.`

Context on why I dropped 'pipefail': https://mywiki.wooledge.org/BashPitfalls#set_-euo_pipefail
In my opinion, 'pipefail' makes debugging even more difficult and doesn't prevent bugs in the first place

The other Bash set builtins have more benefits than downsides, so I kept them.

Everything is using double quotes to make less mistakes:
- Single quotes `''` do not pass through Bash variables.
- Wrapping a directory in quotes prevents a directory with a space or other special symbol from breaking that whole command; inside double quotes `""`, said space or symbol should pass through gracefully and the command would succeed.

A single usage of cat has been replaced with an integrated Bash solution, which is less code and runs faster. No safety improvements here.

The variables containing directory paths are now readonly to emulate the immutable state in Zig.

Now the superuser state is checked, and the macOS SDK even existing is also checked.

Three separate mkdir commands have been combined into one, however the following mkdir commands have been left alone, as it would harm being able to tell the exact flow of the program while reading its code.

Going from `$variable` to now `${variable}` is out of habit, but has a benefit: If you decide to do error checking, it's less bug-prone to do it this way; in other words, this makes it instinctively easier to do shell parameter expansions: https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion
