### PR TITLE
ref: replace stub.c with b.addWriteFiles().add("empty.c", "")

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addStaticLibrary(.{
         .name = "xcode-frameworks",
-        .root_source_file = .{ .path = "stub.c" },
+        .root_source_file = .{ .path = b.addWriteFiles().add("empty.c", "") },
         .target = target,
         .optimize = optimize,
     });

--- a/stub.c
+++ b/stub.c
@@ -1,2 +1,0 @@
-// This file exists for the Zig build sytem to work.
-// In order to "build" this library, there need to be some objects to link.


### PR DESCRIPTION
This amends to https://github.com/hexops/mach/issues/1024 by updating the Zig build file to write towards `empty.c` instead of `stub.c`. No changes were made to any update scripts.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.